### PR TITLE
Update `packages/env`

### DIFF
--- a/apps/web/codegen.ts
+++ b/apps/web/codegen.ts
@@ -3,7 +3,7 @@ import { env } from "@eidolonkit/env/web";
 import type { CodegenConfig } from "@graphql-codegen/cli";
 
 const config: CodegenConfig = {
-  schema: env.NEXT_PUBLIC_PONDER_API_URL,
+  schema: env.NEXT_PUBLIC_PONDER_GRAPHQL_API_URL,
   generates: {
     "./src/generated/schema.graphql": {
       plugins: ["schema-ast"],

--- a/apps/web/src/lib/utils/fetchgql.ts
+++ b/apps/web/src/lib/utils/fetchgql.ts
@@ -23,7 +23,7 @@ const fetchgql = async <TData, TVariables>({
 }: Props<TData, TVariables>): Promise<TData> => {
   const { next, cache, ...restOptions } = options || {};
 
-  const client = new GraphQLClient(env.NEXT_PUBLIC_PONDER_API_URL, {
+  const client = new GraphQLClient(env.NEXT_PUBLIC_PONDER_GRAPHQL_API_URL, {
     headers: {
       "Content-Type": "application/json",
       ...restOptions,

--- a/packages/config/env/src/web.ts
+++ b/packages/config/env/src/web.ts
@@ -9,14 +9,20 @@ export const env = createEnv({
   },
   client: {
     NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID: z.string(),
-    NEXT_PUBLIC_PONDER_API_URL: z
+    NEXT_PUBLIC_PONDER_BASE_API_URL: z
+      .string()
+      .default("http://127.0.0.1:42069"),
+    NEXT_PUBLIC_PONDER_GRAPHQL_API_URL: z
       .string()
       .default("http://127.0.0.1:42069/graphql"),
   },
   runtimeEnv: {
     NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID:
       process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID,
-    NEXT_PUBLIC_PONDER_API_URL: process.env.NEXT_PUBLIC_PONDER_API_URL,
+    NEXT_PUBLIC_PONDER_BASE_API_URL:
+      process.env.NEXT_PUBLIC_PONDER_BASE_API_URL,
+    NEXT_PUBLIC_PONDER_GRAPHQL_API_URL:
+      process.env.NEXT_PUBLIC_PONDER_GRAPHQL_API_URL,
     NODE_ENV: process.env.NODE_ENV,
   },
   emptyStringAsUndefined: true,


### PR DESCRIPTION
## Description

Updated the `web` env configuration to include both a `BASE` and a `GRAPHQL` ponder API endpoint. This is a more descriptive measure to use ponder's newly introduced API functions. It will allow an easy transition as the `ponder` app is iterated on.